### PR TITLE
LPD-24488 Worsened performance when removing setCTCollectionIdWithSafeCloseable

### DIFF
--- a/modules/apps/layout/layout-service/src/main/java/com/liferay/layout/internal/service/LayoutLocalServiceWrapper.java
+++ b/modules/apps/layout/layout-service/src/main/java/com/liferay/layout/internal/service/LayoutLocalServiceWrapper.java
@@ -29,8 +29,6 @@ import com.liferay.layout.util.structure.FragmentStyledLayoutStructureItem;
 import com.liferay.layout.util.structure.LayoutStructure;
 import com.liferay.layout.util.structure.LayoutStructureItem;
 import com.liferay.petra.function.transform.TransformUtil;
-import com.liferay.petra.lang.SafeCloseable;
-import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
 import com.liferay.portal.kernel.comment.CommentManager;
 import com.liferay.portal.kernel.exception.NoSuchLayoutException;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -274,16 +272,7 @@ public class LayoutLocalServiceWrapper
 		ServiceContext currentServiceContext =
 			ServiceContextThreadLocal.getServiceContext();
 
-		long ctCollectionId = sourceLayout.getCtCollectionId();
-
-		if (ctCollectionId == 0) {
-			ctCollectionId = targetLayout.getCtCollectionId();
-		}
-
-		try (SafeCloseable safeCloseable =
-				CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
-					ctCollectionId)) {
-
+		try {
 			CopyLayoutThreadLocal.setCopyLayout(true);
 
 			User user = _getUser(


### PR DESCRIPTION
LayoutLocalServiceCopyLayoutContentTest parametrization

_NUMBER_FRAGMENT_ENTRY_LINKS = 25
_NUMBER_PAGES = 25

testCopyLayoutContentWithPublication execution time before the [last commit ](https://github.com/lfbesada/liferay-portal/commit/fd48cc8f96c3a129664403e71e2ab58e6fdc07e4)

![image](https://github.com/lfbesada/liferay-portal/assets/84471361/85991995-d888-4e45-bcac-ec52ca50e899)


testCopyLayoutContentWithPublication execution time after the [last commit ](https://github.com/lfbesada/liferay-portal/commit/fd48cc8f96c3a129664403e71e2ab58e6fdc07e4)

![image](https://github.com/lfbesada/liferay-portal/assets/84471361/f7c8874a-1cac-4aff-adea-6d4413068157)


